### PR TITLE
Always show all table columns on mobile

### DIFF
--- a/views/expenses/index.ejs
+++ b/views/expenses/index.ejs
@@ -54,21 +54,21 @@
             </div>
         </div>
     </div>
-    <div class="col-md-12">
+    <div class="col-md-12 table-responsive">
         <table class="table table-hover">
             <thead class="table-light">
                 <tr>
-                    <th class="d-none d-sm-block" scope="col">#</th>
+                    <th class="col" scope="col">#</th>
                     <th scope="col">Datum</th>
                     <th scope="col">Kategorija</th>
                     <th scope="col">Strošek</th>
-                    <th class="d-none d-sm-block" scope="col">Plačnik</th>
+                    <th class="col" scope="col">Plačnik</th>
                 </tr>
             </thead>
             <tbody>
                 <% for (let i = 0; i < expenses.length; i++) { %>
                 <tr>
-                    <th class="d-none d-sm-block" scope="row"><%= i+1 %></th>
+                    <td class="col" scope="row"><%= i+1 %></th>
                     <td>
                         <a href="/expenses/<%= expenses[i].id %>">
                             <%=expenses[i].payDate.toLocaleDateString('locales')
@@ -76,7 +76,7 @@
                     </td>
                     <td><%=expenses[i].categoryLabel %></td>
                     <td><%=expenses[i].cost %> €</td>
-                    <td class="d-none d-sm-block">
+                    <td class="col">
                         <%=expenses[i].payer.username %>
                     </td>
                 </tr>

--- a/views/expenses/search.ejs
+++ b/views/expenses/search.ejs
@@ -47,21 +47,21 @@
             </div>
         </form>
     </div>
-    <div class="col-md-12">
+    <div class="col-md-12 table-responsive">
         <table class="table table-hover">
             <thead class="table-light">
                 <tr>
-                    <th class="d-none d-sm-block" scope="col">#</th>
+                    <th class="col" scope="col">#</th>
                     <th scope="col">Datum</th>
                     <th scope="col">Kategorija</th>
                     <th scope="col">Strošek</th>
-                    <th class="d-none d-sm-block" scope="col">Plačnik</th>
+                    <th class="col" scope="col">Plačnik</th>
                 </tr>
             </thead>
             <tbody>
                 <% for (let i = 0; i < context.expenses.length; i++) { %>
                 <tr>
-                    <th class="d-none d-sm-block" scope="row"><%= i+1 %></th>
+                    <td class="col" scope="row"><%= i+1 %></th>
                     <td>
                         <a href="/expenses/<%= context.expenses[i]._id %>">
                             <%=context.expenses[i].payDate.toLocaleDateString('locales')
@@ -69,7 +69,7 @@
                     </td>
                     <td><%=context.expenses[i].category[0].name %></td>
                     <td><%=context.expenses[i].cost %> €</td>
-                    <td class="d-none d-sm-block">
+                    <td class="col">
                         <%=context.expenses[i].payer[0].username %>
                     </td>
                 </tr>


### PR DESCRIPTION
A customer complained because they can't see the _Payer_ column in the expense list on mobile.

This column was previously hidden to save space, but after this PR it's visible and we instead use Bootstrap's `.table-responsive` class to make the table horizontally scrollable when it's too wide for the viewport.

### Demo
https://user-images.githubusercontent.com/1853648/185805495-321c6ea4-e316-4e03-b181-9d62b3523e9d.mp4

