### PR TITLE
Create a  user/household settings page

### DIFF
--- a/app.js
+++ b/app.js
@@ -547,7 +547,7 @@ app.get(
     '/settings',
     isLoggedIn,
     catchAsync(async (req, res) => {
-        const user = await getLoggedinUser(req, res)
+        const user = await getLoggedinUser(req)
         const household = user.household
         res.render('users/settings', { user, household })
     }),
@@ -576,7 +576,7 @@ app.post(
             `${req.session.passport.user}, pozdravljen v GosGos!`,
         )
         //on login get users household and save it in session
-        const loggedinUser = await getLoggedinUser(req, res)
+        const loggedinUser = await getLoggedinUser(req)
         req.session.household = loggedinUser.household._id
         req.session.usersID = loggedinUser._id
         res.redirect(redirectUrl)

--- a/app.js
+++ b/app.js
@@ -71,7 +71,6 @@ const MongoStore = require('connect-mongo')
 const { authenticate } = require('passport')
 const { emitKeypressEvents } = require('readline')
 const { isEmpty } = require('lodash')
-const user = require('./models/user')
 
 const dbUrl = process.env.DB_URL
 //const dbUrl = 'mongodb://localhost:27017/gos-gos'

--- a/app.js
+++ b/app.js
@@ -47,6 +47,8 @@ const {
     getPopularCategories,
 } = require('./controllers/categories')
 
+const { updateSettings } = require('./controllers/settings')
+
 const {
     getAllLoggedInUserDebits,
     createDebit,
@@ -543,6 +545,15 @@ app.get(
         const user = await getLoggedinUser(req, res)
         const household = user.household
         res.render('users/settings', { user, household })
+    }),
+)
+app.post(
+    '/settings',
+    isLoggedIn,
+    catchAsync(async (req, res) => {
+        await updateSettings(req)
+        req.flash('success', 'Nastavitve so bile uspešno shranjene.')
+        res.redirect(`/settings`)
     }),
 )
 

--- a/app.js
+++ b/app.js
@@ -166,6 +166,7 @@ app.get(
             res,
         )
         const popularCategories = await getPopularCategories(req)
+        const currentHousehold = (await getLoggedinUser(req)).household
 
         res.render('expenses/create-edit', {
             users,
@@ -175,6 +176,7 @@ app.get(
             usersExpenses,
             mode: 'create',
             popularCategories: popularCategories,
+            currentHousehold,
         })
     }),
 )
@@ -201,12 +203,15 @@ app.get(
             req.flash('error', 'Iskanega stroška ni moč najti!')
             return res.redirect('/expenses/new')
         }
+        const currentHousehold = (await getLoggedinUser(req)).household
+
         res.render('expenses/create-edit', {
             expense,
             users,
             categories,
             mode: 'edit',
             popularCategories,
+            currentHousehold,
         })
     }),
 )

--- a/app.js
+++ b/app.js
@@ -560,8 +560,8 @@ app.post(
         )
         //on login get users household and save it in session
         const loggedinUser = await getLoggedinUser(req, res)
-        req.session.household = loggedinUser[0].household._id
-        req.session.usersID = loggedinUser[0]._id
+        req.session.household = loggedinUser.household._id
+        req.session.usersID = loggedinUser._id
         res.redirect(redirectUrl)
     },
 )

--- a/app.js
+++ b/app.js
@@ -540,8 +540,9 @@ app.get(
     '/settings',
     isLoggedIn,
     catchAsync(async (req, res) => {
-        const loggedinUser = await getLoggedinUser(req, res)
-        res.render('users/settings', loggedinUser)
+        const user = await getLoggedinUser(req, res)
+        const household = user.household
+        res.render('users/settings', { user, household })
     }),
 )
 

--- a/controllers/settings.js
+++ b/controllers/settings.js
@@ -1,0 +1,21 @@
+const User = require('../models/user')
+const Household = require('../models/household')
+
+module.exports.updateSettings = async (req) => {
+    const formData = req.body
+
+    // Fetch current user and household from DB
+    const currentUser = await User.findOne({ _id: req.session.usersID })
+    const currentHousehold = await Household.findOne({
+        _id: req.session.household,
+    })
+
+    // Set new settings based on values from form
+    currentUser.color = formData.color
+    currentHousehold.defaultToSharedExpense =
+        formData.defaultToSharedExpense === 'true'
+
+    // Save both objects
+    await currentUser.save()
+    await currentHousehold.save()
+}

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -19,7 +19,7 @@ module.exports.logoutUser = (req, res, next) => {
 }
 
 module.exports.getLoggedinUser = async (req, res) => {
-    const loggedinUser = await User.find({
+    const loggedinUser = await User.findOne({
         username: req.session.passport.user,
     }).populate('household')
     return loggedinUser

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -18,7 +18,7 @@ module.exports.logoutUser = (req, res, next) => {
     })
 }
 
-module.exports.getLoggedinUser = async (req, res) => {
+module.exports.getLoggedinUser = async (req) => {
     const loggedinUser = await User.findOne({
         username: req.session.passport.user,
     }).populate('household')

--- a/migrations/20231101181307-populate-default-to-shared-expense.js
+++ b/migrations/20231101181307-populate-default-to-shared-expense.js
@@ -1,0 +1,13 @@
+module.exports = {
+    async up(db, client) {
+        return db
+            .collection('households')
+            .updateMany({}, { $set: { defaultToSharedExpense: true } })
+    },
+
+    async down(db, client) {
+        return db
+            .collection('households')
+            .updateMany({}, { $unset: { defaultToSharedExpense: 1 } })
+    },
+}

--- a/models/household.js
+++ b/models/household.js
@@ -21,5 +21,9 @@ const householdSchema = new Schema({
     color: {
         type: String, //https://coolors.co/palette/264653-287271-2a9d8f-8ab17d-babb74-e9c46a-efb366-f4a261-ee8959-e76f51
     },
+    defaultToSharedExpense: {
+        type: Boolean,
+        required: true,
+    },
 })
 module.exports = mongoose.model('Household', householdSchema)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "chart.js": "^4.4.0",
                 "connect-flash": "^0.1.1",
                 "connect-mongo": "^5.0.0",
                 "cron-job-manager": "^2.3.1",
@@ -710,11 +709,6 @@
             "engines": {
                 "node": ">=0.1.90"
             }
-        },
-        "node_modules/@kurkle/color": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
-            "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
         },
         "node_modules/@mongodb-js/saslprep": {
             "version": "1.1.0",
@@ -1573,17 +1567,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/chart.js": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.0.tgz",
-            "integrity": "sha512-vQEj6d+z0dcsKLlQvbKIMYFHd3t8W/7L2vfJIbYcfyPcRx92CsHqECpueN8qVGNlKyDcr5wBrYAYKnfu/9Q1hQ==",
-            "dependencies": {
-                "@kurkle/color": "^0.3.0"
-            },
-            "engines": {
-                "pnpm": ">=7"
             }
         },
         "node_modules/chokidar": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "author": "BaM",
     "license": "ISC",
     "dependencies": {
-        "chart.js": "^4.4.0",
         "connect-flash": "^0.1.1",
         "connect-mongo": "^5.0.0",
         "cron-job-manager": "^2.3.1",

--- a/views/expenses/create-edit.ejs
+++ b/views/expenses/create-edit.ejs
@@ -150,9 +150,6 @@
             </div>
 
             <div class="mb-3">
-                <label class="form-check-label" for="flexSwitchCheckChecked"
-                    >Deljen strošek</label
-                >
                 <div class="form-check form-switch">
                     <input
                         class="form-check-input"
@@ -165,6 +162,7 @@
                             checked
                         <% } %>
                     />
+                    <label class="form-check-label" for="flexSwitchCheckChecked">Deljen strošek</label>
                 </div>
             </div>
 

--- a/views/expenses/create-edit.ejs
+++ b/views/expenses/create-edit.ejs
@@ -161,7 +161,7 @@
                         id="flexSwitchCheckChecked"
                         name="expense[shared]"
                         value="true"
-                        <% if (mode === 'create' || expense?.shared) { %>
+                        <% if (currentHousehold.defaultToSharedExpense || expense?.shared) { %>
                             checked
                         <% } %>
                     />

--- a/views/layouts/boilerplate.ejs
+++ b/views/layouts/boilerplate.ejs
@@ -12,9 +12,9 @@
             type="image/png"
         />
         <link
-            href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+            href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
             rel="stylesheet"
-            integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
+            integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN"
             crossorigin="anonymous"
         />
         <link rel="stylesheet" href="/stylesheets/app.css" />
@@ -31,8 +31,8 @@
             crossorigin="anonymous"
         ></script>
         <script
-            src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.min.js"
-            integrity="sha384-QJHtvGhmr9XOIpI6YVutG+2QOK9T+ZnN4kzFN1RtK3zEFEIsxhlmWl5/YESvpZ13"
+            src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.min.js"
+            integrity="sha384-BBtl+eGJRgqQAUMxJ7pMwbEyER4l1g+O15P+16Ep7Q9Q+zqX6gSbd85u4mG4QzX+"
             crossorigin="anonymous"
         ></script>
         <script src="https://cdn.jsdelivr.net/npm/bs-custom-file-input/dist/bs-custom-file-input.min.js"></script>

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -1,5 +1,5 @@
 <nav class="navbar sticky-top navbar-expand-lg navbar-dark bg-dark">
-    <div class="container-fluid">
+    <div class="container">
         <a class="navbar-brand" href="/expenses/new">
             <img
                 src="https://img.freepik.com/free-vector/cute-little-goose-cartoon-flying_188253-3207.jpg?w=2000"

--- a/views/users/settings.ejs
+++ b/views/users/settings.ejs
@@ -1,11 +1,65 @@
-<% layout('layouts/boilerplate')%>
-<div class="container d-flex justify-content-center align-items-center mt-5">
-    <div class="row">
-        <div class="col-md-6 offset-md-3 col-xl-4 offset-xl-4">
-            <a class="nav-link" href="/settings/changepassword"
-                >Spremeni geslo</a
-            >
-            <h5 class="card-title"></h5>
+<% layout('layouts/boilerplate', { containerClass: 'banana' })%>
+
+<h1>Nastavitve</h1>
+
+<form action="/settings" method="post">
+    <fieldset>
+        <legend>Uporabnik</legend>
+
+        <div class="mb-3">
+            <label for="color" class="form-label">Barva</label>
+            <input
+                type="color"
+                class="form-control"
+                id="color"
+                name="color"
+                value="<%= user.color %>"
+                required
+            />
         </div>
-    </div>
-</div>
+    </fieldset>
+    <fieldset>
+        <legend>Gospodinjstvo</legend>
+
+        <div class="mb-3">
+            <label class="form-label">Privzeta oblika stroška</label>
+            <div class="form-check">
+                <input
+                    class="form-check-input"
+                    type="radio"
+                    name="defaultToSharedExpense"
+                    id="defaultToSharedExpenseTrue"
+                    value="true"
+                    autocomplete="off"
+                    <% if (household.defaultToSharedExpense === true) { %>
+                        checked
+                    <% } %>
+                />
+                <label class="form-check-label" for="defaultToSharedExpenseTrue"
+                    >Deljen</label
+                >
+            </div>
+            <div class="form-check">
+                <input
+                    class="form-check-input"
+                    type="radio"
+                    name="defaultToSharedExpense"
+                    id="defaultToSharedExpenseFalse"
+                    value="false"
+                    autocomplete="off"
+                    <% if (household.defaultToSharedExpense === false) { %>
+                        checked
+                    <% } %>
+                    required
+                />
+                <label
+                    class="form-check-label"
+                    for="defaultToSharedExpenseFalse"
+                    >Individualen</label
+                >
+            </div>
+        </div>
+    </fieldset>
+    <hr />
+    <button type="submit" class="btn btn-primary btn-lg mt-3">Shrani</button>
+</form>


### PR DESCRIPTION
:warning: Depends on #13, that one must be merged first!
:warning: Includes a migration, run `npx migrate-mongo up` in production after deploying.

This PR implements a settings page. It's accessible by clicking on the username top right. On the new page the user can:
- Change their color (user setting)
- Change whether a new expense is shared or not by default (household setting)

See [demo](https://github.com/Bam3/GosGos/assets/1853648/894e4ca2-b200-4daf-bdb9-f194455c66cd), I forgot to make the cursor visible, pay attention to the shared expense toggle.
